### PR TITLE
Added navigation state to dashboard

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -4,6 +4,9 @@ import { getStyle } from './scss/styles.scss';
 import Header from './components/Header';
 import SideNav from './components/SideNav';
 import Footer from './components/Footer';
+import Menu from './components/Menu';
+import NodeGraphContainer from './containers/NodeGraphContainer';
+import LogsContainer from './containers/LogsContainer';
 
 const App: React.FC = () => {
   // REMEMBER: When passing state using TypeScript you need to setup an interface in the child component with the format of the props you want to pass in
@@ -12,18 +15,34 @@ const App: React.FC = () => {
   // render page based on state
   const [open, openDrawer] = useState<boolean>(false);
 
+  //Page navigation state
+  const [selection, menuSelect] = useState<string>('main');
+
   const toggleDrawer = (event: MouseEvent) => {
     if (open === false) openDrawer(true);
     if (open === true) openDrawer(false);
   };
 
+  //Decides which page to render
+  let page;
+  switch(selection){
+    case 'main':
+      page = <MainDashboard open={open} />
+      break;
+    case 'node':
+      page = <NodeGraphContainer open={open} />
+      break;
+    case 'logs':
+      page = <LogsContainer open={open} />
+      break;
+  }
+
   return (
     <div style={getStyle} id='origin'>
       <Header open={open} toggleDrawer={toggleDrawer} />
+      <Menu menuSelect={menuSelect}/>
       <SideNav open={open} toggleDrawer={toggleDrawer} />
-      <MainDashboard open={open} />
-      {/* Log Dashboard */}
-      {/* Node Graph Dashboard */}
+      {page}
       <Footer open={open} />
     </div>
   );

--- a/client/components/Menu.tsx
+++ b/client/components/Menu.tsx
@@ -1,0 +1,39 @@
+import React, { Dispatch, MouseEventHandler, SetStateAction } from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import { IconButton } from '@mui/material';
+import { ButtonGroup } from '@mui/material';
+import { Button } from '@mui/material';
+
+const style = {
+  button: {
+    background: '#2a65e8'
+  },
+  button_selected: {
+    background: 'cyan'
+  }
+};
+
+interface MenuProps {
+  menuSelect: Dispatch<SetStateAction<string>>;
+}
+
+function Menu(props: MenuProps) {
+  const { menuSelect } = props;
+
+  return (
+    <div id='menu-container'>
+      <div id='menu'>
+        <div></div>
+          <ButtonGroup variant="contained" aria-label="outlined primary button group">
+            <Button style={style.button} onClick={() => {menuSelect('main')}}>Main Dashboard</Button>
+            <Button style={style.button} onClick={() => {menuSelect('node')}}>Node Graph</Button>
+            <Button style={style.button} onClick={() => {menuSelect('logs')}}>Logs Dashboard</Button>
+          </ButtonGroup>
+        <div></div>
+      </div>
+    </div>
+  );
+}
+
+export default Menu;

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -59,6 +59,17 @@ iframe {
   color: white;
 }
 
+/* MENU CSS */
+#menu-container {
+  padding: 0rem 1.5rem;
+}
+
+#menu {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto;
+}
+
 /* SIDENAV CSS*/
 #chevron {
   background: $headerColor;

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,1 +1,12 @@
-<!doctype html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><script src="dist/bundle.js"></script><title>Moat</title><script defer="defer" src="/bundle.js"></script></head><body><div id="root"></div></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="dist/bundle.js" type="text/javascript"></script>
+    <title>Moat</title>
+<script defer src="/bundle.js"></script></head>
+<body>
+    <div id="root"></div>
+</body>
+</html>


### PR DESCRIPTION
## Why is this feature needed?
In order to navigate between different parts of our dashboard, we need a navigation state handler. This feature comes with a button menu that allows a user to switch between the 'main', 'node', and 'logs' dashboards

## What should the reviewer look at? (specific questions, particular files, etc) 
The file I added was Menu, within components. I made changes in the App.tsx file, and within our styles.scss

## Share a summary of your approach (any tech/dependencies involved, tutorials that assisted you with build, AND/OR design patterns/algo strategies)
Within App.tsx, I created a state handler that takes a string as an input. I then added a switch statement that checks the state for specific strings associated with our pages. Within the Menu.tsx (which has been added to App.jsx), the useState function tied to the handler is prop-drilled and called within the individual buttons. Each button feeds a different string to the state handler, making the switch statement change and re-render the currently displayed page.

## If you considered other solutions, why did you not implement them?
Another solution we considered was the use of a router, but we implemented this to keep our application as one page for the time being.

## Does the build break? 
No, it does not

## Code Author Checklist 
- [ V] I cleaned up my code before making my pull request. 
- [ V] I kept my pull request small, so code can be reviewed easier.
- [ V] I updated the documentation and project hub as needed. 