### PR TITLE
Adjust CSS on side navbar to set header height to same as main page

### DIFF
--- a/moat-dashboard/client/components/SideNav.tsx
+++ b/moat-dashboard/client/components/SideNav.tsx
@@ -42,8 +42,8 @@ function SideNav(props: NavProps) {
         </IconButton>
       </div>
       <div id='nav-content'>
-        <Menu menuSelect={menuSelect} />
         <div id='top-nav-content'>
+          <Menu menuSelect={menuSelect} />
           <p className='large-text'>
             <strong>moat</strong> is a security-first monitoring tool that
             watches over Kubernetes clusters. View health data on the main

--- a/moat-dashboard/client/scss/styles.scss
+++ b/moat-dashboard/client/scss/styles.scss
@@ -64,23 +64,12 @@ iframe {
   color: white;
 }
 
-/* MENU CSS */
-#menu-container {
-  padding: 0rem 1.5rem;
-}
-
-#menu {
-  display: flex;
-  justify-content: space-between;
-  margin: 0 auto;
-}
-
 /* SIDENAV CSS*/
 #chevron {
   background: #87abf8;
   box-shadow: 2px 2px 10px rgb(209, 208, 208);
   text-align: right;
-  padding: 0.07rem 1.5rem;
+  padding: 0.4rem 1.5rem;
 }
 
 #nav-content {
@@ -89,7 +78,18 @@ iframe {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 60vh;
+  height: 100vh;
+}
+
+#menu-container {
+  padding: 0rem 1.5rem;
+}
+
+#menu {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto;
+  padding-bottom: 2rem;
 }
 
 .large-text {


### PR DESCRIPTION
## What was the bug behavior? 
The sidebar header height was shorter than the main page header height. 

## What is the behavior now? 
The heights are the same. 

## What should the reviewer look at? (specific questions, particular files, etc)
styles.scss in moat-dashboard directory

## Share a summary of your solution 
Adjust padding on sidenav header to make heights the same

## Steps to Reproduce (if helpful for rest of team)


## Code Author Checklist 
- [x] I cleaned up my code before making my pull request. 
- [x] I kept my pull request small, so code can be reviewed easier.
- [x] I updated the documentation and project hub as needed. 